### PR TITLE
Add `cwd` option

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -41,17 +41,22 @@ export default defineConfig({
 // Create 'page' directories at 'src/blog' and `src/projects`
 pages(
   'blog', 
-  'projects'
+  {
+    dir: 'projects'
+  }
 )
 ```
 
-**Resolve your own directories**
+**Customize base directory for relative paths**
 
 ```js
-// Create 'page' directories in folder `/custom` at root of project
 pages(
-  resolve(import.meta.env, "custom") 
-)
+  {
+    // Resolves to 'custom' dir at the root of your project
+    dir: 'custom',
+    cwd: import.meta.url, // astro.config.mjs
+  },
+),
 ```
 
 **Ignoring routes**
@@ -117,10 +122,10 @@ export default function(options): AstroIntegration {
       'astro:config:setup': ({ config, logger, injectRoute }) => {
         
           const option = {
-            dir: 'custom',
-            glob: '["**.{astro,ts,js}", "!**/ignore/**"]'
-            pattern: ({ pattern }) => '/base' + pattern 
-            log: "verbose"
+            cwd: import.meta.url,
+            dir: 'pages',
+            glob: '["**.{astro,ts,js}"]'
+            log: "minimal"
             config,
             logger,
             injectRoute
@@ -147,6 +152,14 @@ export default function(options): AstroIntegration {
 **Type**: `string`
 
 Directory of pages, relative dirs are resolved relative to `srcDir` (`/src` by default). Directories located outside the root of your project may cause problems.
+
+### `cwd`
+
+**Type**: `string`
+
+**Default**: Astro config `srcDir`
+
+Directory that the `dir` option is resolved to if it is relative. If the `cwd` option is relative it is resolved relative to the `srcDir` in Astro config (`/src` by default).
 
 ### `glob`
 

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-pages",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Add custom file based routing directories in Astro",
   "keywords": [
     "astro",

--- a/package/types.ts
+++ b/package/types.ts
@@ -4,6 +4,7 @@ export type Prettify<T> = { [K in keyof T]: T[K]; } & {};
 
 export interface Option {
   log?: "verbose" | "minimal" | boolean | null | undefined;
+  cwd?: string;
   dir: string;
   glob?: string | string[];
   pattern?: (context: {

--- a/package/types.ts
+++ b/package/types.ts
@@ -8,10 +8,11 @@ export interface Option {
   dir: string;
   glob?: string | string[];
   pattern?: (context: {
-    dir: string | undefined;
+    cwd: string;
+    dir: string;
     entrypoint: string;
     ext: string;
-    pattern: string | undefined;
+    pattern: string;
   }) => string;
 }
 

--- a/package/utils/add-page-dir.ts
+++ b/package/utils/add-page-dir.ts
@@ -17,7 +17,7 @@ function stringToDir(option: IntegrationOption, key: 'dir' | 'cwd', path?: strin
 
   // Check if path is a file URL
   if (path.startsWith('file:/')) {
-    if (log === "minimal") logger.warn(`'${key}' is a file, using file's directory instead`)
+    if (log === "verbose") logger.warn(`'${key}' is a file, using file's directory instead`)
     path = dirname(fileURLToPath(path))
   } 
 
@@ -28,7 +28,7 @@ function stringToDir(option: IntegrationOption, key: 'dir' | 'cwd', path?: strin
 
   // Check if path is a file
   if (extname(path)) {
-    if (log === "minimal") logger.warn(`'${key}' is a file, using file's directory instead`)
+    if (log === "verbose") logger.warn(`'${key}' is a file, using file's directory instead`)
     path = dirname(path)
   }
 

--- a/package/utils/add-page-dir.ts
+++ b/package/utils/add-page-dir.ts
@@ -5,57 +5,66 @@ import { fileURLToPath } from 'node:url';
 import { existsSync} from 'node:fs';
 import fg from 'fast-glob';
 
+function stringToDir(option: IntegrationOption, key: 'dir' | 'cwd', path: string, base?: string) {
+  const { log, config, logger } = option
+  
+  const srcDir = fileURLToPath(config.srcDir.toString())
+
+  const cwd = base && stringToDir(option, 'cwd', base) || srcDir
+
+  // Check if path is string
+  if (!path || typeof path !== "string") {
+    throw new AstroError(`[astro-pages]: '${key}' is invalid!`, path)
+  }
+
+  // Check if path is a file URL
+  if (path.startsWith('file:/')) {
+    if (log === "minimal") logger.warn(`'${key}' is a file, using file's directory instead`)
+    path = dirname(fileURLToPath(path))
+  } 
+
+  // Check if path is relative
+  if (!isAbsolute(path)) {
+    path = resolve(cwd, path)
+  }
+
+  // Check if path is a file
+  if (extname(path)) {
+    if (log === "minimal") logger.warn(`'${key}' is a file, using file's directory instead`)
+    path = dirname(path)
+  }
+
+  // Check if path exists
+  if (!existsSync(path)) {
+    throw new AstroError(`[astro-pages]: '${key}' does not exist!`, path)
+  }
+
+  // Check if path is pointing to Astro's page directory
+  if (path === resolve(srcDir, 'pages')) {
+    throw new AstroError(`[astro-pages]: '${key}' cannot point to Astro's 'pages' directory!`)
+  }
+
+  return path
+}
+
 export function addPageDir(options: IntegrationOption) {
 
   let {
     dir,
+    cwd,
     glob,
     pattern: transformer,
     log,
-    config,
     logger,
     injectRoute
   } = options
 
-  const srcDir = fileURLToPath(config.srcDir.toString())
-
-  // Handle users not setting dir correctly
-  if (!dir || typeof dir !== "string") {
-    throw new AstroError(`[astro-pages]: 'dir' is invalid!`, dir)
-  }
-
-  // Check if dir is a file URL
-  if (dir.startsWith('file:/')) {
-    if (log === "minimal") logger.warn(`'dir' is a file, using file's directory instead`)
-    dir = dirname(fileURLToPath(dir))
-  } 
-
-  // If dir is relative, resolve it relative to srcDir
-  if (!isAbsolute(dir)) {
-    dir = resolve(srcDir, dir)
-  }
-
-  // Check if dir is a file
-  if (extname(dir)) {
-    if (log === "minimal") logger.warn(`'dir' is a file, using file's directory instead`)
-    dir = dirname(dir)
-  }
-
-  // Check if dir exists
-  if (!existsSync(dir)) {
-    throw new AstroError(`[astro-pages]: 'dir' does not exist!`, dir)
-  }
-
-  // Check if dir is pointing to Astro's page directory
-  if (dir === resolve(srcDir, 'pages')) {
-    throw new AstroError(`[astro-pages]: 'dir' cannot point to Astro's 'pages' directory!`)
-  }
+  dir = stringToDir(options, 'dir', dir, cwd)
 
   // Handle glob default including empty array case
   if (!glob || (Array.isArray(glob) && !glob.length)) {
     glob = '**.{astro,ts,js}'
   }
-
   
   // Glob filepaths of pages from dir
   const entrypoints = fg.sync(
@@ -67,7 +76,6 @@ export function addPageDir(options: IntegrationOption) {
     ].flat(),
     { cwd: dir, absolute: true }
   )
-
 
   // Turn entrypoints into patterns ('/blog', '/about/us')
   let patterns: Record<string, string> = {}

--- a/playground/astro.config.mjs
+++ b/playground/astro.config.mjs
@@ -8,7 +8,8 @@ export default defineConfig({
       // 'src/custom/nested',
       {
         log: "verbose",
-        dir: "custom",
+        cwd: import.meta.url,
+        dir: "pages",
         glob: ['**.{astro,ts,js}', '!**/nested/**.{astro,ts,js}'],
         pattern: ({ pattern }) => pattern
       }


### PR DESCRIPTION
- Added `cwd` option to control the base path that relative paths are resolved to. Defaults to Astro's `srcDir`
- Improved types for pattern transformer
- Added examples to README