### PR TITLE
Export `GLOB_PAGES` utility for building glob patterns

### DIFF
--- a/.changeset/clever-avocados-cover.md
+++ b/.changeset/clever-avocados-cover.md
@@ -1,0 +1,5 @@
+---
+"astro-pages": patch
+---
+
+Export `GLOB_PAGES` constant ("\*\*.{astro,ts,js}") for building glob patterns

--- a/package/index.ts
+++ b/package/index.ts
@@ -1,6 +1,6 @@
 import type { AstroIntegration } from "astro";
 import type { IntegrationOption, Option, Prettify } from "./types";
-import addPageDir from "./utils/add-page-dir";
+import { addPageDir, GLOB_PAGES } from "./utils/add-page-dir";
 
 export default function (
 	...options: (string | Prettify<Option>)[]
@@ -40,4 +40,4 @@ export default function (
 	};
 }
 
-export { addPageDir };
+export { addPageDir, GLOB_PAGES };

--- a/package/index.ts
+++ b/package/index.ts
@@ -1,6 +1,6 @@
 import type { AstroIntegration } from "astro";
 import type { IntegrationOption, Option, Prettify } from "./types";
-import { addPageDir, GLOB_PAGES } from "./utils/add-page-dir";
+import { GLOB_PAGES, addPageDir } from "./utils/add-page-dir";
 
 export default function (
 	...options: (string | Prettify<Option>)[]

--- a/package/utils/add-page-dir.ts
+++ b/package/utils/add-page-dir.ts
@@ -48,10 +48,11 @@ function stringToDir(
 	return path;
 }
 
-export default function addPageDir(options: IntegrationOption) {
+export function addPageDir(options: IntegrationOption) {
 	let {
 		dir,
 		cwd,
+		glob = GLOB_PAGES,
 		pattern: transformer,
 		log,
 		config,
@@ -142,3 +143,5 @@ export default function addPageDir(options: IntegrationOption) {
 		injectPages,
 	};
 }
+
+export default addPageDir

--- a/package/utils/add-page-dir.ts
+++ b/package/utils/add-page-dir.ts
@@ -5,6 +5,8 @@ import { AstroError } from "astro/errors";
 import fg from "fast-glob";
 import type { IntegrationOption } from "../types";
 
+export const GLOB_PAGES = "**.{astro,ts,js}"
+
 function stringToDir(
 	option: IntegrationOption,
 	key: "dir" | "cwd",
@@ -50,7 +52,6 @@ export default function addPageDir(options: IntegrationOption) {
 	let {
 		dir,
 		cwd,
-		glob,
 		pattern: transformer,
 		log,
 		config,
@@ -65,8 +66,8 @@ export default function addPageDir(options: IntegrationOption) {
 	dir = stringToDir(options, "dir", cwd, dir);
 
 	// Handle glob default including empty array case
-	if (!glob || (Array.isArray(glob) && !glob.length)) {
-		glob = "**.{astro,ts,js}";
+	if (Array.isArray(glob) && glob.length <= 0) {
+		glob = GLOB_PAGES;
 	}
 
 	// Glob filepaths of pages from dir

--- a/package/utils/add-page-dir.ts
+++ b/package/utils/add-page-dir.ts
@@ -5,7 +5,7 @@ import { AstroError } from "astro/errors";
 import fg from "fast-glob";
 import type { IntegrationOption } from "../types";
 
-export const GLOB_PAGES = "**.{astro,ts,js}"
+export const GLOB_PAGES = "**.{astro,ts,js}";
 
 function stringToDir(
 	option: IntegrationOption,
@@ -144,4 +144,4 @@ export function addPageDir(options: IntegrationOption) {
 	};
 }
 
-export default addPageDir
+export default addPageDir;


### PR DESCRIPTION
- Export `GLOB_PAGES` utility for building glob patterns
- Update glob default to use GLOB_PAGES
- Add named export for `addPageDir` utility